### PR TITLE
Fix `Ruby::UnannotatedEmptyCollection` in `steep check`

### DIFF
--- a/lib/ruby_header_parser/parser.rb
+++ b/lib/ruby_header_parser/parser.rb
@@ -93,8 +93,11 @@ module RubyHeaderParser
     def extract_enum_definitions
       stdout = execute_ctags("--c-kinds=e --fields=+n")
 
+      # Workaround for Ruby::UnannotatedEmptyCollection on steep 1.9.0+
+      name_to_definition = {} #: Hash[String, RubyHeaderParser::EnumDefinition] # rubocop:disable Layout/LeadingCommentSpace
+
       name_to_definitions =
-        stdout.each_line.with_object({}) do |line, hash|
+        stdout.each_line.with_object(name_to_definition) do |line, hash|
           parts = line.split("\t")
 
           enum_name = Util.find_field(parts, "enum")


### PR DESCRIPTION
```
Warning: header_parser/parser.rb:97:37: [warning] Empty hash doesn't have type annotation
│ Diagnostic ID: Ruby::UnannotatedEmptyCollection
│
└         stdout.each_line.with_object({}) do |line, hash|
                                       ~~

Detected 1 problem from 1 file
rake aborted!
Command failed with status (1): [steep check]
/home/runner/work/ruby_header_parser/ruby_header_parser/Rakefile:24:in `block in <top (required)>'
/home/runner/work/ruby_header_parser/ruby_header_parser/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/exe/rake:27:in `<top (required)>'
/opt/hostedtoolcache/Ruby/3.3.6/x64/bin/bundle:25:in `load'
/opt/hostedtoolcache/Ruby/3.3.6/x64/bin/bundle:25:in `<main>'
Tasks: TOP => rbs
(See full trace by running task with --trace)
```