### PR TITLE
Fix build error with Ruby 3.4 + GitHub Actions (Ubuntu 22.04)

### DIFF
--- a/config/default.yml.erb
+++ b/config/default.yml.erb
@@ -75,6 +75,9 @@ function:
     - rb_newobj_of
     - rb_st_init_existing_table_with_size
     - rb_st_replace
+
+    # FIXME: Workaround for "undefined reference to `rb_undefine_finalizer'" on GitHub Actions (Ubuntu 22.04)
+    - rb_undefine_finalizer
     <% end %>
 
   pointer_hint:


### PR DESCRIPTION
```
/usr/bin/ld: /tmp/go-link-3220631292/000004.o: in function `_cgo_9bbe2ed3d113_Cfunc_rb_undefine_finalizer':
/tmp/go-build/cgo-gcc-prolog:16245: undefined reference to `rb_undefine_finalizer'
collect2: error: ld returned 1 exit status
```

c.f. https://github.com/ruby-go-gem/go-gem-wrapper/actions/runs/12635579314/job/35205800481?pr=244

ref. https://github.com/ruby-go-gem/go-gem-wrapper/pull/244