### PR TITLE
Treat `RSTRING_END` return value as a `char*` instead of `string`

### DIFF
--- a/config/default.yml.erb
+++ b/config/default.yml.erb
@@ -81,6 +81,8 @@ function:
     <% end %>
 
   pointer_hint:
+    RSTRING_END:
+      self: raw
     RSTRING_PTR:
       self: raw
     rb_data_object_make:

--- a/spec/ruby_header_parser/parser_spec.rb
+++ b/spec/ruby_header_parser/parser_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe RubyHeaderParser::Parser do
 
       its(:name)       { should eq "RSTRING_END" }
       its(:definition) { should eq "RSTRING_END(VALUE str)" }
-      its(:typeref)    { should eq typeref(type: "char", pointer: :ref) }
+      its(:typeref)    { should eq typeref(type: "char", pointer: :raw) }
       its(:args)       { should eq args }
     end
 


### PR DESCRIPTION
`RSTRING_END` expects pointer to return

https://github.com/ruby/ruby/blob/v3_4_2/include/ruby/internal/core/rstring.h#L434-L442