### PR TITLE
Revert "Fix error in rspec-parameterized-table_syntax"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,5 @@
 
 source "https://rubygems.org"
 
-# FIXME: Workaround for Ruby 4.0+
-# https://github.com/banister/binding_of_caller/pull/90
-gem "binding_of_caller", github: "kivikakk/binding_of_caller", branch: "push-yrnnzolypxun"
-
 # Specify your gem's dependencies in ruby_header_parser.gemspec
 gemspec


### PR DESCRIPTION
This reverts commit 789a2e77fd240273a0ff8a51bada31a37ec4c0db.