### PR TITLE
CI against for Ruby 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
         ruby:
           - "3.3"
           - "3.4"
+          - "4.0"
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,37 @@ jobs:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK }}
 
+  yard:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - uses: ruby/setup-ruby@ae195bbe749a7cef685ac729197124a48305c1cb # v1.276.0
+        with:
+          ruby-version: ruby
+          bundler-cache: true
+
+      - name: bundle update
+        run: |
+          set -xe
+          bundle config path vendor/bundle
+          bundle update --all --jobs $(nproc) --retry 3
+
+      - name: yard generating test
+        run: |
+          set -xe
+          bundle exec yard
+          ls -ld doc/
+
+      - name: Slack Notification (not success)
+        uses: act10ns/slack@cfcc30955fe9377f4f55e1079e5419ee1014269f # v2
+        if: "! success()"
+        continue-on-error: true
+        with:
+          status: ${{ job.status }}
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+
   all-pass:
     if: always()
 
@@ -112,6 +143,7 @@ jobs:
       - test
       - rubocop
       - rbs
+      - yard
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           set -xe
           bundle config path vendor/bundle
-          bundle update --jobs $(nproc) --retry 3
+          bundle update --all --jobs $(nproc) --retry 3
 
       - run: sudo apt-get update
       - run: sudo apt-get install -y universal-ctags
@@ -65,7 +65,7 @@ jobs:
         run: |
           set -xe
           bundle config path vendor/bundle
-          bundle update --jobs $(nproc) --retry 3
+          bundle update --all --jobs $(nproc) --retry 3
 
       - run: bundle exec rake rubocop
 
@@ -92,7 +92,7 @@ jobs:
         run: |
           set -xe
           bundle config path vendor/bundle
-          bundle update --jobs $(nproc) --retry 3
+          bundle update --all --jobs $(nproc) --retry 3
 
       - run: bundle exec rake rbs:install
       - run: bundle exec rake rbs

--- a/ruby_header_parser.gemspec
+++ b/ruby_header_parser.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rbs", ">= 3.7.0"
+  spec.add_development_dependency "rdoc"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-its"
   spec.add_development_dependency "rspec-parameterized"

--- a/ruby_header_parser.gemspec
+++ b/ruby_header_parser.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
 
+  spec.add_development_dependency "irb"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rbs", ">= 3.7.0"
   spec.add_development_dependency "rdoc"


### PR DESCRIPTION
Fix yard generating at ruby 4.0 and add ruby 4.0 to matrix

https://github.com/ruby-go-gem/ruby_header_parser/actions/runs/20548111590/job/59021544427

```
Run bundle exec yard --output-dir "${DOC_DIR}"
/home/runner/work/ruby_header_parser/ruby_header_parser/vendor/bundle/ruby/4.0.0/gems/yard-0.9.38/lib/yard/templates/helpers/markup_helper.rb:105: warning: rdoc used to be loaded from the standard library, but is not part of the default gems since Ruby 4.0.0.
You can add rdoc to your Gemfile or gemspec to fix this error.
Error: : Missing 'redcarpet' gem for Markdown formatting. Install it with `gem install redcarpet`
```